### PR TITLE
Make test file path in examples relative

### DIFF
--- a/tests/c_examples/atoi/test_task/test_task.json
+++ b/tests/c_examples/atoi/test_task/test_task.json
@@ -1,42 +1,42 @@
 [
     {
-        "command": "sactor run-tests --type bin /home/qsdrqs/sactor/tests/c_examples/atoi/test_task/test_samples.json %t 0 --feed-as-args",
+        "command": "sactor run-tests --type bin ./test_samples.json %t 0 --feed-as-args",
         "test_id": 0
     },
     {
-        "command": "sactor run-tests --type bin /home/qsdrqs/sactor/tests/c_examples/atoi/test_task/test_samples.json %t 1 --feed-as-args",
+        "command": "sactor run-tests --type bin ./test_samples.json %t 1 --feed-as-args",
         "test_id": 1
     },
     {
-        "command": "sactor run-tests --type bin /home/qsdrqs/sactor/tests/c_examples/atoi/test_task/test_samples.json %t 2 --feed-as-args",
+        "command": "sactor run-tests --type bin ./test_samples.json %t 2 --feed-as-args",
         "test_id": 2
     },
     {
-        "command": "sactor run-tests --type bin /home/qsdrqs/sactor/tests/c_examples/atoi/test_task/test_samples.json %t 3 --feed-as-args",
+        "command": "sactor run-tests --type bin ./test_samples.json %t 3 --feed-as-args",
         "test_id": 3
     },
     {
-        "command": "sactor run-tests --type bin /home/qsdrqs/sactor/tests/c_examples/atoi/test_task/test_samples.json %t 4 --feed-as-args",
+        "command": "sactor run-tests --type bin ./test_samples.json %t 4 --feed-as-args",
         "test_id": 4
     },
     {
-        "command": "sactor run-tests --type bin /home/qsdrqs/sactor/tests/c_examples/atoi/test_task/test_samples.json %t 5 --feed-as-args",
+        "command": "sactor run-tests --type bin ./test_samples.json %t 5 --feed-as-args",
         "test_id": 5
     },
     {
-        "command": "sactor run-tests --type bin /home/qsdrqs/sactor/tests/c_examples/atoi/test_task/test_samples.json %t 6 --feed-as-args",
+        "command": "sactor run-tests --type bin ./test_samples.json %t 6 --feed-as-args",
         "test_id": 6
     },
     {
-        "command": "sactor run-tests --type bin /home/qsdrqs/sactor/tests/c_examples/atoi/test_task/test_samples.json %t 7 --feed-as-args",
+        "command": "sactor run-tests --type bin ./test_samples.json %t 7 --feed-as-args",
         "test_id": 7
     },
     {
-        "command": "sactor run-tests --type bin /home/qsdrqs/sactor/tests/c_examples/atoi/test_task/test_samples.json %t 8 --feed-as-args",
+        "command": "sactor run-tests --type bin ./test_samples.json %t 8 --feed-as-args",
         "test_id": 8
     },
     {
-        "command": "sactor run-tests --type bin /home/qsdrqs/sactor/tests/c_examples/atoi/test_task/test_samples.json %t 9 --feed-as-args",
+        "command": "sactor run-tests --type bin ./test_samples.json %t 9 --feed-as-args",
         "test_id": 9
     }
 ]

--- a/tests/c_examples/const_global/test_task/test_task.json
+++ b/tests/c_examples/const_global/test_task/test_task.json
@@ -1,22 +1,22 @@
 [
     {
-        "command": "sactor run-tests --type bin /home/qsdrqs/sactor/tests/c_examples/const_global/test_task/test_samples.json %t 0 --feed-as-args",
+        "command": "sactor run-tests --type bin ./test_samples.json %t 0 --feed-as-args",
         "test_id": 0
     },
     {
-        "command": "sactor run-tests --type bin /home/qsdrqs/sactor/tests/c_examples/const_global/test_task/test_samples.json %t 1 --feed-as-args",
+        "command": "sactor run-tests --type bin ./test_samples.json %t 1 --feed-as-args",
         "test_id": 1
     },
     {
-        "command": "sactor run-tests --type bin /home/qsdrqs/sactor/tests/c_examples/const_global/test_task/test_samples.json %t 2 --feed-as-args",
+        "command": "sactor run-tests --type bin ./test_samples.json %t 2 --feed-as-args",
         "test_id": 2
     },
     {
-        "command": "sactor run-tests --type bin /home/qsdrqs/sactor/tests/c_examples/const_global/test_task/test_samples.json %t 3 --feed-as-args",
+        "command": "sactor run-tests --type bin ./test_samples.json %t 3 --feed-as-args",
         "test_id": 3
     },
     {
-        "command": "sactor run-tests --type bin /home/qsdrqs/sactor/tests/c_examples/const_global/test_task/test_samples.json %t 4 --feed-as-args",
+        "command": "sactor run-tests --type bin ./test_samples.json %t 4 --feed-as-args",
         "test_id": 4
     }
 ]

--- a/tests/c_examples/enum/test_task/test_task.json
+++ b/tests/c_examples/enum/test_task/test_task.json
@@ -1,30 +1,30 @@
 [
     {
-        "command": "sactor run-tests --type bin /home/qsdrqs/.cache/sactor/test_task/test_samples.json %t 0 --feed-as-args",
+        "command": "sactor run-tests --type bin ./test_samples.json %t 0 --feed-as-args",
         "test_id": 0
     },
     {
-        "command": "sactor run-tests --type bin /home/qsdrqs/.cache/sactor/test_task/test_samples.json %t 1 --feed-as-args",
+        "command": "sactor run-tests --type bin ./test_samples.json %t 1 --feed-as-args",
         "test_id": 1
     },
     {
-        "command": "sactor run-tests --type bin /home/qsdrqs/.cache/sactor/test_task/test_samples.json %t 2 --feed-as-args",
+        "command": "sactor run-tests --type bin ./test_samples.json %t 2 --feed-as-args",
         "test_id": 2
     },
     {
-        "command": "sactor run-tests --type bin /home/qsdrqs/.cache/sactor/test_task/test_samples.json %t 3 --feed-as-args",
+        "command": "sactor run-tests --type bin ./test_samples.json %t 3 --feed-as-args",
         "test_id": 3
     },
     {
-        "command": "sactor run-tests --type bin /home/qsdrqs/.cache/sactor/test_task/test_samples.json %t 4 --feed-as-args",
+        "command": "sactor run-tests --type bin ./test_samples.json %t 4 --feed-as-args",
         "test_id": 4
     },
     {
-        "command": "sactor run-tests --type bin /home/qsdrqs/.cache/sactor/test_task/test_samples.json %t 5 --feed-as-args",
+        "command": "sactor run-tests --type bin ./test_samples.json %t 5 --feed-as-args",
         "test_id": 5
     },
     {
-        "command": "sactor run-tests --type bin /home/qsdrqs/.cache/sactor/test_task/test_samples.json %t 6 --feed-as-args",
+        "command": "sactor run-tests --type bin ./test_samples.json %t 6 --feed-as-args",
         "test_id": 6
     }
 ]

--- a/tests/c_examples/typedef/test_task/test_task.json
+++ b/tests/c_examples/typedef/test_task/test_task.json
@@ -1,50 +1,50 @@
 [
     {
-        "command": "sactor run-tests --type bin /home/qsdrqs/sactor/tests/c_examples/typedef/test_task/test_samples.json %t 0 --feed-as-args",
+        "command": "sactor run-tests --type bin ./test_samples.json %t 0 --feed-as-args",
         "test_id": 0
     },
     {
-        "command": "sactor run-tests --type bin /home/qsdrqs/sactor/tests/c_examples/typedef/test_task/test_samples.json %t 1 --feed-as-args",
+        "command": "sactor run-tests --type bin ./test_samples.json %t 1 --feed-as-args",
         "test_id": 1
     },
     {
-        "command": "sactor run-tests --type bin /home/qsdrqs/sactor/tests/c_examples/typedef/test_task/test_samples.json %t 2 --feed-as-args",
+        "command": "sactor run-tests --type bin ./test_samples.json %t 2 --feed-as-args",
         "test_id": 2
     },
     {
-        "command": "sactor run-tests --type bin /home/qsdrqs/sactor/tests/c_examples/typedef/test_task/test_samples.json %t 3 --feed-as-args",
+        "command": "sactor run-tests --type bin ./test_samples.json %t 3 --feed-as-args",
         "test_id": 3
     },
     {
-        "command": "sactor run-tests --type bin /home/qsdrqs/sactor/tests/c_examples/typedef/test_task/test_samples.json %t 4 --feed-as-args",
+        "command": "sactor run-tests --type bin ./test_samples.json %t 4 --feed-as-args",
         "test_id": 4
     },
     {
-        "command": "sactor run-tests --type bin /home/qsdrqs/sactor/tests/c_examples/typedef/test_task/test_samples.json %t 5 --feed-as-args",
+        "command": "sactor run-tests --type bin ./test_samples.json %t 5 --feed-as-args",
         "test_id": 5
     },
     {
-        "command": "sactor run-tests --type bin /home/qsdrqs/sactor/tests/c_examples/typedef/test_task/test_samples.json %t 6 --feed-as-args",
+        "command": "sactor run-tests --type bin ./test_samples.json %t 6 --feed-as-args",
         "test_id": 6
     },
     {
-        "command": "sactor run-tests --type bin /home/qsdrqs/sactor/tests/c_examples/typedef/test_task/test_samples.json %t 7 --feed-as-args",
+        "command": "sactor run-tests --type bin ./test_samples.json %t 7 --feed-as-args",
         "test_id": 7
     },
     {
-        "command": "sactor run-tests --type bin /home/qsdrqs/sactor/tests/c_examples/typedef/test_task/test_samples.json %t 8 --feed-as-args",
+        "command": "sactor run-tests --type bin ./test_samples.json %t 8 --feed-as-args",
         "test_id": 8
     },
     {
-        "command": "sactor run-tests --type bin /home/qsdrqs/sactor/tests/c_examples/typedef/test_task/test_samples.json %t 9 --feed-as-args",
+        "command": "sactor run-tests --type bin ./test_samples.json %t 9 --feed-as-args",
         "test_id": 9
     },
     {
-        "command": "sactor run-tests --type bin /home/qsdrqs/sactor/tests/c_examples/typedef/test_task/test_samples.json %t 10 --feed-as-args",
+        "command": "sactor run-tests --type bin ./test_samples.json %t 10 --feed-as-args",
         "test_id": 10
     },
     {
-        "command": "sactor run-tests --type bin /home/qsdrqs/sactor/tests/c_examples/typedef/test_task/test_samples.json %t 11 --feed-as-args",
+        "command": "sactor run-tests --type bin ./test_samples.json %t 11 --feed-as-args",
         "test_id": 11
     }
 ]


### PR DESCRIPTION
Code already runs all tests in the test_tasks folder.
https://github.com/qsdrqs/sactor/blob/360ecd5b3d2e5adb80151c445258c81f0b884f38/README.md?plain=1#L182
